### PR TITLE
Allow IP routing for http server demo.

### DIFF
--- a/src/lwip_setup.c
+++ b/src/lwip_setup.c
@@ -177,10 +177,12 @@ void setup_gmac_ethernet(void)
 
 #ifdef USE_DHCP
     /*
-     * interface must be "admin up" when DHCP is started
+     * interface must be "admin up" when DHCP is started.  set to default
+     * interface to allow ip routing.
      */
 
     netif_set_up(eth);  
+    netif_set_default(eth);
     dhcp_start(eth);
 #else
     /*


### PR DESCRIPTION
This fixes an issue where the http server only communicates within its own subnet.  To allow routing to other subnets, the default interface must be used to perform IP routing.